### PR TITLE
client-side validation of ESNIKeys

### DIFF
--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -29,6 +29,7 @@ author:
 normative:
   RFC1035:
   RFC2119:
+  RFC6234:
 
 informative:
 
@@ -179,6 +180,7 @@ structure, defined below.
     } ESNIKeyShareEntry;
 
     struct {
+        uint8 checksum[4];
         ESNIKeyShareEntry keys<4..2^16-1>;
         CipherSuite cipher_suites<2..2^16-2>;
         uint16 padded_length;
@@ -192,6 +194,11 @@ label
 
 share
 : An (EC)DH key share (attached to the label)
+
+checksum
+: First four (4) octets of the SHA-256 message digest {{RFC6234}} of the
+ESNIKeys structure starting from the first octet of "keys" to the end of
+the stucture.
 
 keys
 : The list of keys which can be used by the client to encrypt the SNI.
@@ -250,8 +257,12 @@ by a fronting server can guess the correct SNI with probability at least
 1/K, where K is the size of this hidden server anonymity set. This probability
 may be increased via traffic analysis or other mechanisms.
 
+The "checksum" field provides protection against transmission errors,
+including those caused by intermediaries such as a DNS proxy running on a
+home router.
 "not_before" and "not_after" fields represent the validity period of the
-published ESNI keys. Clients MUST NOT use ESNI keys beyond the published
+published ESNI keys. Clients MUST NOT use ESNI keys that was covered by an
+invalid checksum or beyond the published
 period. Servers SHOULD set the Resource Record TTL small enough so that the
 record gets discarded by the cache before the ESNI keys reach the end of
 their validity period.

--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -182,6 +182,8 @@ structure, defined below.
         ESNIKeyShareEntry keys<4..2^16-1>;
         CipherSuite cipher_suites<2..2^16-2>;
         uint16 padded_length;
+        uint64 not_before;
+        uint64 not_after;
     } ESNIKeys;
 ~~~~
 
@@ -204,6 +206,14 @@ expects to support rounded up the nearest multiple of 16.
 a hash of the server name. This would be fixed-length, but
 have the disadvantage that the server has to retain a table
 of all the server names it supports.]]
+
+not_before
+: The moment when the keys become valid for use. The value is represented
+as seconds from 00:00:00 UTC on Jan 1 1970, not including leap seconds.
+
+not_after
+: The moment when the keys become invalid. Uses the same unit as
+not_before.
 
 The semantics of this structure are simple: any of the listed keys may
 be used to encrypt the SNI for the associated domain name.
@@ -240,10 +250,14 @@ by a fronting server can guess the correct SNI with probability at least
 1/K, where K is the size of this hidden server anonymity set. This probability
 may be increased via traffic analysis or other mechanisms.
 
-The Resource Record TTL determines the lifetime of the published ESNI keys.
-Clients MUST NOT use ESNI keys beyond their published lifetime. Note that the
-length of this structure MUST NOT exceed 2^16 - 1, as the RDLENGTH is only 16
-bits {{RFC1035}}.
+"not_before" and "not_after" fields represent the validity period of the
+published ESNI keys. Clients MUST NOT use ESNI keys beyond the published
+period. Servers SHOULD set the Resource Record TTL small enough so that the
+record gets discarded by the cache before the ESNI keys reach the end of
+their validity period.
+
+Note that the length of this structure MUST NOT exceed 2^16 - 1, as the
+RDLENGTH is only 16 bits {{RFC1035}}.
 
 # The "encrypted_server_name" extension {#esni-extension}
 


### PR DESCRIPTION
I expect that the resistance against ESNIKeys will come from web-site owners worrying about ESNIKeys being additional source of service disruption.

One might argue that the probability of disruption becomes 2x because now two resource records (A and _esni) are involved instead of just one. One might argue that the probability is higher than that because there could be more issues with carrying large TXT records than carrying A records. One might argue that the probability is below 2x because the two records are transmitted through the same path.

Anyways, these arguments are about the quantitative difference about the probability.

I prefer having a qualitative guarantee, that assures that there would be no increase in the probability of service disruption assuming that the owner of the `_esni` record does not misconfigure the service.

Having a checksum and validity period fields that can be validated by the client provides such guarantee.

Checksum provides protection against accidental corruption.

Validity period provides protection against misconfiguration or bugs in the DNS servers. It acts as a protection against an outdated ESNIKeys sent by an out-of-sync authoritative server or a buggy resolver causing disruption.

The downside of having checksum and validity is that the additional payload (currently 20 bytes, I think we can minimize this to 10 bytes by removing `not_before` (it's not that needed) and changing the type of `not_after` from `uint64` to `uint48`), and that the client would be required to do the validation.

But I assume that having qualitative guarantee that the probability of service disruption remains the same is worth the effort.

Closes #20.