### PR TITLE
prevent downgrade attack

### DIFF
--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -175,24 +175,18 @@ structure, defined below.
 
     struct {
         opaque label<0..2^8-1>;
-        KeyShareEntry share;
-    } ESNIKeyShareEntry;
-
-    struct {
-        ESNIKeyShareEntry keys<4..2^16-1>;
+        KeyShareEntry keys<4..2^16-1>;
         CipherSuite cipher_suites<2..2^16-2>;
         uint16 padded_length;
     } ESNIKeys;
 ~~~~
 
 label
-: An opaque label to use for a given key.
-
-share
-: An (EC)DH key share (attached to the label)
+: An opaque label used to identify the list of keys.
 
 keys
 : The list of keys which can be used by the client to encrypt the SNI.
+Every key being listed MUST belong to a different group.
 
 padded_length
 : The length to pad the ServerNameList value to prior to encryption.
@@ -275,8 +269,7 @@ encrypted_sni
 
 In order to send an encrypted SNI, the client MUST first select one of
 the server ESNIKeyShareEntry values and generate an (EC)DHE share in the
-matching group. If multiple keys (labels) for the same IP address are available,
-clients SHOULD choose one at random. This share is then used for the client's "key_share"
+matching group. This share is then used for the client's "key_share"
 extension and will be used to derive both the SNI encryption
 key the (EC)DHE shared secret which is used in the TLS key schedule.
 This has two important implications:
@@ -487,7 +480,8 @@ Server operators may partition their private keys however they see fit provided
 each server behind an IP address has the corresponding private key to decrypt
 a key. Thus, when one ESNI key is provided, sharing is optimally bound by the number
 of hosts that share an IP address. Server operators may further limit sharing
-by including multiple keys, with distinct labels, in an ESNIKeys structure.
+by sending different Resource Records containing ESNIKeys with different keys
+covered by different labels using a short TTL.
 
 ### Prevent SNI-based DoS attacks
 

--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -280,11 +280,6 @@ The encrypted SNI is carried in an "encrypted_server_name"
 extension, which contains an EncryptedSNI structure:
 
 ~~~~
-   // Copied from TLS 1.3
-   struct {
-       NamedGroup named_group_list<2..2^16-1>;
-   } NamedGroupList;
-
    struct {
        opaque label<0..2^8-1>;
        CipherSuite suite;

--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -245,8 +245,14 @@ The encrypted SNI is carried in an "encrypted_server_name"
 extension, which contains an EncryptedSNI structure:
 
 ~~~~
+   // Copied from TLS 1.3
+   struct {
+       NamedGroup named_group_list<2..2^16-1>;
+   } NamedGroupList;
+
    struct {
        opaque label<0..2^8-1>;
+       NamedGroupList offered_groups;
        CipherSuite suite;
        opaque encrypted_sni<0..2^16-1>;
    } EncryptedSNI;
@@ -254,6 +260,10 @@ extension, which contains an EncryptedSNI structure:
 
 label
 : The label associated with the SNI encryption key.
+
+offered_groups
+: The list of named groups offered by the SNI encryption key, in the order
+  they were offered.
 
 suite
 : The cipher suite used to encrypt the SNI.
@@ -342,6 +352,11 @@ MUST first perform the following checks:
   "illegal_parameter" alert.
   [[OPEN ISSUE: We looked at ignoring the extension but concluded
   this was better.]]
+
+- If the list of the Named Groups provided by EncryptedSNI.offered_groups
+  does not exactly match the named groups that were offered by the SNI
+  encryption key identified by the label, it MUST abort the connection
+  with an "illegal_parameter" alert.
 
 - If more than one KeyShareEntry has been provided, or if that share's
   group does not match that for the SNI encryption key, it MUST abort


### PR DESCRIPTION
In ESNI, the server offers a list of ECDH keys and the client selects one of them. However, there seems to be nothing that prevents a downgrade attack.

This PR adds the protection, by sending the list of the Named Groups being offered by ESNIKeys in the EncryptedSNI extension.

The bonus is that the size of ESNIKeys becomes smaller when more than one keys are offered (because we now only send one label per the entire key set).