### PR TITLE
clarify that limitation of hash-based protection

### DIFF
--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -203,7 +203,9 @@ expects to support rounded up the nearest multiple of 16.
 [[OPEN ISSUE: An alternative to padding is to instead send
 a hash of the server name. This would be fixed-length, but
 have the disadvantage that the server has to retain a table
-of all the server names it supports.]]
+of all the server names it supports, and will not work if
+the mapping between the fronting server and the hidden server
+uses wildcards.]]
 
 The semantics of this structure are simple: any of the listed keys may
 be used to encrypt the SNI for the associated domain name.


### PR DESCRIPTION
The approach does not work if the mapping between the fronting server and the hidden server contains a wildcard.