### PR TITLE
ServerNameList should be 260 octets long for fronting servers with wildcard support

### DIFF
--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -211,7 +211,7 @@ padded_length
 The length to pad the ServerNameList value to prior to encryption. 
 This value SHOULD be set to the largest ServerNameList the server 
 expects to support rounded up the nearest multiple of 16. If the 
-server supports wildcard names, it SHOULD set this value to 256. 
+server supports wildcard names, it SHOULD set this value to 260.
 
 not_before
 : The moment when the keys become valid for use. The value is represented


### PR DESCRIPTION
Because the longest name is 255 octets (see RFC 1035), and there is 5-octet overhead in the ServerNameList structure (defined in RFC 6066 as shown below).

```
      struct {
          NameType name_type;
          select (name_type) {
              case host_name: HostName;
          } name;
      } ServerName;

      enum {
          host_name(0), (255)
      } NameType;

      opaque HostName<1..2^16-1>;

      struct {
          ServerName server_name_list<1..2^16-1>
      } ServerNameList;
```

amends #48 