### PR TITLE
Remove OPEN ISSUE about sending empty ESNI in EE

### DIFF
--- a/draft-rescorla-tls-esni.md
+++ b/draft-rescorla-tls-esni.md
@@ -442,10 +442,6 @@ SHOULD pad the Certificate message, via padding at the record layer
 such that its length equals the size of the largest possible Certificate
 (message) covered by the same ESNI key.
 
-[[OPEN ISSUE: Do we want "encrypted_server_name" in EE? It's
-clearer communication, but would make it so you could not
-operate a current TLS 1.3 server as a backend server.]]
-
 # Compatibility Issues
 
 In general, this mechanism is designed only to be used with


### PR DESCRIPTION
As per discussion in https://github.com/ekr/draft-rescorla-tls-esni/pull/55
this would require changes to Split Mode backend servers, and it turns out
that even for plain "server_name" this behaviour is pretty much useless.